### PR TITLE
Add extension.json; Make most tests use it

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,0 +1,18 @@
+{
+	"name": "PageImporter",
+	"version": "0.1.0",
+	"author": [
+		"[https://www.mediawiki.org/wiki/User:Jamesmontalvo3 James Montalvo]"
+	],
+	"url": "http://github.com/enterprisemediawiki/PageImporter",
+	"descriptionmsg": "pageimporter-desc",
+	"type": "other",
+	"AutoloadClasses": {
+		"PageImporter": "PageImporter.class.php"
+	},
+	"MessagesDirs": {
+		"Wiretap": [
+			"i18n"
+		]
+	}
+}

--- a/tests/travis/install-extensions.sh
+++ b/tests/travis/install-extensions.sh
@@ -22,7 +22,11 @@ echo "" >> LocalSettings.php
 echo "\$wgShowExceptionDetails = true;" >> LocalSettings.php
 
 echo "" >> LocalSettings.php
-echo "require_once \"$MW_INSTALL_PATH/extensions/PageImporter/PageImporter.php\";" >> LocalSettings.php
+if [ "$LOAD_TYPE" = "extension.json" ]; then
+	echo "wfLoadExtension('PageImporter');" >> LocalSettings.php
+else
+	echo "require_once \"$MW_INSTALL_PATH/extensions/PageImporter/PageImporter.php\";" >> LocalSettings.php
+fi
 echo "" >> LocalSettings.php
 
 cp -r $MW_INSTALL_PATH/extensions/PageImporter/tests/ExampleExtension $MW_INSTALL_PATH/extensions/ExampleExtension


### PR DESCRIPTION
Add an `extension.json` file. Make test cases that specify `LOAD_TYPE=extension.json` load PageImporter with `wfLoadExtension` (i.e. using `extension.json`). Previously `LOAD_TYPE=extension.json` just loaded ExampleExtension via `wfLoadExtension`.