### PR TITLE
Use User::newSystemUser for maint user

### DIFF
--- a/PageImporter.class.php
+++ b/PageImporter.class.php
@@ -91,7 +91,7 @@ class PageImporter { // phpcs:ignore MediaWiki.Files.ClassMatchesFilename.NotMat
 			$pages = $this->getPages( $groupInfo['pages'] );
 
 			global $wgUser;
-			$wgUser = User::newFromName( 'Maintenance script' );
+			$wgUser = User::newSystemUser( 'Maintenance script', [ 'steal' => true ] );
 
 			foreach ( $pages as $pageTitleText => $filePath ) {
 

--- a/tests/travis/run-tests.sh
+++ b/tests/travis/run-tests.sh
@@ -43,8 +43,8 @@ fn_compare_file_with_page "Template:Test" "Template/Test.mediawiki"
 fn_compare_file_with_page "Category:Test_Category" "Category/Test_Category.mediawiki"
 
 # Edit pages
-echo "New template text" | php $MW_INSTALL_PATH/maintenance/edit.php -u Tester "Template:Test"
-echo "New category text" | php $MW_INSTALL_PATH/maintenance/edit.php -u Tester "Category:Test_Category"
+echo "New template text" | php $MW_INSTALL_PATH/maintenance/edit.php "Template:Test"
+echo "New category text" | php $MW_INSTALL_PATH/maintenance/edit.php "Category:Test_Category"
 
 fn_compare_file_with_page "Template:Test" "Template/Test.mediawiki" "no"
 fn_compare_file_with_page "Category:Test_Category" "Category/Test_Category.mediawiki" "no"


### PR DESCRIPTION
When CI was initially setup, there were issues with running `edit.php` without specifying a user on MW 1.33+. It turns out that is because PageImporter was doing `User::newFromName( 'Maintenance script' )` which was taking ownership of the `Maintenance user`. This caused this [1] failure.

Initially this PR just fixed usage of `newFromName`. However, I realized it would be good to show the fix. So I inserted a commit before that fix which removed `-u Tester` from the `edit.php` usage. I let this commit run tests, which failed for the reason mentioned above. I then re-pushed the fix, changing `newFromName` to `newSystemUser`

For some reason GitHub didn't reorder the commits list below when I force-pushed them. They are reordered in general in GitHub...just not in the output below. Maybe that'll update at some point, but right now it shows the latest commit failing and the first one passing (should be the other way around).

Closes #9 

[1] https://travis-ci.org/enterprisemediawiki/PageImporter/jobs/545929168#L780-L783